### PR TITLE
选项拆分

### DIFF
--- a/src/main/java/burp/scanner/Log4j2Scanner.java
+++ b/src/main/java/burp/scanner/Log4j2Scanner.java
@@ -252,6 +252,9 @@ public class Log4j2Scanner implements IScannerCheck {
                 if (Config.getBoolean(Config.ENABLED_FUZZ_HEADER, true)) {
                     domainMap.putAll(headerFuzz(baseRequestResponse, req));
                 }
+                if (Config.getBoolean(Config.ADD_FUZZ_HEADER, true)) {
+                    domainMap.putAll(headerAdd(baseRequestResponse, req));
+                }
             } else {
                 domainMap.putAll(crazyFuzz(baseRequestResponse, req));
             }
@@ -418,6 +421,18 @@ public class Log4j2Scanner implements IScannerCheck {
                     }
                 }
             }
+        } catch (Exception ex) {
+            ex.printStackTrace(parent.stderr);
+        }
+        return domainMap;
+    }
+
+    private Map<String, ScanItem> headerAdd (IHttpRequestResponse baseRequestResponse, IRequestInfo req) {
+        List<String> headers = req.getHeaders();
+        Map<String, ScanItem> domainMap = new HashMap<>();
+        try {
+            byte[] rawRequest = baseRequestResponse.getRequest();
+            List<String> guessHeaders = new ArrayList(Arrays.asList(HEADER_GUESS));
             for (IPOC poc : getSupportedPOCs()) {
                 List<String> tmpHeaders = new ArrayList<>(headers);
                 Map<String, String> domainHeaderMap = new HashMap<>();

--- a/src/main/java/burp/ui/tabs/FuzzUIHandler.java
+++ b/src/main/java/burp/ui/tabs/FuzzUIHandler.java
@@ -18,6 +18,7 @@ public class FuzzUIHandler {
     private JComboBox scanModeSelector;
     private JCheckBox enabled_ex_request;
     private JCheckBox enabled_fuzz_header;
+    private JCheckBox add_fuzz_header;
     private JCheckBox enabled_fuzz_url;
     private JCheckBox enabled_fuzz_body;
     private JCheckBox enabled_fuzz_cookie;
@@ -71,8 +72,12 @@ public class FuzzUIHandler {
         subPanel11.add(enabled_ex_request);
 
         JPanel subPanel1 = UIUtil.GetXJPanel();
-        enabled_fuzz_header = new JCheckBox("Enable Header Fuzz");
+        enabled_fuzz_header = new JCheckBox("Replace Header Fuzz");
         subPanel1.add(enabled_fuzz_header);
+
+        JPanel subPanel12 = UIUtil.GetXJPanel();
+        add_fuzz_header = new JCheckBox("Add Header Fuzz");
+        subPanel12.add(add_fuzz_header);
 
         JPanel subPanel2 = UIUtil.GetXJPanel();
         enabled_fuzz_url = new JCheckBox("Enable Url Fuzz");
@@ -136,6 +141,7 @@ public class FuzzUIHandler {
         panel1.add(subPanel10);
         panel1.add(subPanel11);
         panel1.add(subPanel1);
+        panel1.add(subPanel12);
         panel1.add(subPanel2);
         panel1.add(subPanel3);
         panel1.add(subPanel4);
@@ -152,6 +158,7 @@ public class FuzzUIHandler {
         fuzzModeSelector.setSelectedItem(Config.get(Config.FUZZ_MODE, Config.FuzzMode.EachFuzz.name()));
         scanModeSelector.setSelectedItem(Config.get(Config.SCAN_MODE, Config.ScanMode.Passive.name()));
         enabled_fuzz_header.setSelected(Config.getBoolean(Config.ENABLED_FUZZ_HEADER, true));
+        add_fuzz_header.setSelected(Config.getBoolean(Config.ADD_FUZZ_HEADER, true));
         enabled_fuzz_url.setSelected(Config.getBoolean(Config.ENABLED_FUZZ_URL, true));
         enabled_fuzz_body.setSelected(Config.getBoolean(Config.ENABLED_FUZZ_BODY, true));
         enabled_fuzz_cookie.setSelected(Config.getBoolean(Config.ENABLED_FUZZ_COOKIE, true));
@@ -167,6 +174,7 @@ public class FuzzUIHandler {
         Config.set(Config.FUZZ_MODE, fuzzModeSelector.getSelectedItem().toString());
         Config.set(Config.SCAN_MODE, scanModeSelector.getSelectedItem().toString());
         Config.setBoolean(Config.ENABLED_FUZZ_HEADER, enabled_fuzz_header.isSelected());
+        Config.setBoolean(Config.ADD_FUZZ_HEADER, add_fuzz_header.isSelected());
         Config.setBoolean(Config.ENABLED_FUZZ_URL, enabled_fuzz_url.isSelected());
         Config.setBoolean(Config.ENABLED_FUZZ_BODY, enabled_fuzz_body.isSelected());
         Config.setBoolean(Config.ENABLED_FUZZ_COOKIE, enabled_fuzz_cookie.isSelected());

--- a/src/main/java/burp/utils/Config.java
+++ b/src/main/java/burp/utils/Config.java
@@ -26,6 +26,7 @@ public class Config {
     public static final String SelfDigPm_ADMIN_URL = "DIGPM_admin_url";
     public static final String SelfDigPm_TOKEN = "DIGPM_token";
     public static final String ENABLED_FUZZ_HEADER = "enabled_fuzz_header";
+    public static final String ADD_FUZZ_HEADER = "add_fuzz_header";
     public static final String ENABLED_FUZZ_URL = "enabled_fuzz_url";
     public static final String ENABLED_FUZZ_BODY = "enabled_fuzz_body";
     public static final String ENABLED_FUZZ_COOKIE = "enabled_fuzz_cookie";


### PR DESCRIPTION
把原先的 Enable Header Fuzz 选项拆分为 Replace Header Fuzz 和 Add Header Fuzz
主要是批量过站点时, headerFuzz 里面发的请求太多了,想着把最后一个添加header头的fuzz包留着就行了,所以拆分一下

<img width="271" alt="image" src="https://user-images.githubusercontent.com/18167071/209046511-07ada7cd-59aa-404f-b86d-efa3e01a7221.png">
<img width="634" alt="image" src="https://user-images.githubusercontent.com/18167071/209046638-0ef04917-d599-454d-9eaa-38809d23d804.png">
